### PR TITLE
OpenAPI 3 Implements (draft)

### DIFF
--- a/modules/reitit-openapi/project.clj
+++ b/modules/reitit-openapi/project.clj
@@ -1,0 +1,12 @@
+(defproject metosin/reitit-swagger "0.5.16"
+  :description "Reitit: OpenAPI-support (alpha)"
+  :url "https://github.com/MokkeMeguru/reitit"
+  :license {:name "Eclipse Public License"
+            :url "http://www.eclipse.org/legal/epl-v10.html"}
+  :scm {:name "git"
+        :url "https://github.com/MokkeMeguru/reitit"
+        :dir "../.."}
+  :plugins [[lein-parent "0.3.2"]]
+  :parent-project {:path "../../project.clj"
+                   :inherit [:deploy-repositories :managed-dependencies]}
+  :dependencies [[metosin/reitit-core]])

--- a/modules/reitit-openapi/src/openapi.cljc
+++ b/modules/reitit-openapi/src/openapi.cljc
@@ -1,0 +1,114 @@
+(ns reitit.openapi
+  (:require [clojure.set :as set]
+            [clojure.spec.alpha :as s]
+            [reitit.trie :as trie]
+            [clojure.string :as str]
+            [reitit.core :as r]
+            [reitit.coercion :as coercion]
+            [meta-merge.core :refer [meta-merge]]))
+
+(def openapi-version "3.1.0")
+(s/def ::id (s/or :keyword keyword? :set (s/coll-of keyword? :into #{})))
+(s/def ::no-doc boolean?)
+(s/def ::tags (s/coll-of (s/or :keyword keyword? :string string?) :kind #{}))
+(s/def ::summary string?)
+(s/def ::description string?)
+
+(s/def ::openapi (s/keys :opt-un [::id]))
+(s/def ::spec (s/keys :opt-un [::openapi ::no-doc ::tags ::summary ::description]))
+
+(def openapi-feature
+  "Feature for handling openapi-documentation for routes.
+  Works both Middleware & Interceptors. Does not perticipate
+  in actual request processing, jist provides specs for the new
+  documentation keys for the route data. Should be accompanied by a
+  [[openapi-spec-handler]] to expose the openapi spec.
+
+  New route data keys contributing to openapi docs:
+
+  | key           | description |
+  | --------------|-------------|
+  | :openapi      | map of any openapi-data. Must have `:id` (keyword or sequence of keywords) to identify the api
+  | :no-doc       | optional boolean to exclude endpoint from api docs
+  | :summary      | optional short string summary of an endpoint
+  | :description  | optional long description of an endpoint. Supports http://spec.commonmark.org/
+
+  Also the coercion keys contribute to openapi spec:
+
+  | key           | description |
+  | --------------|-------------|
+  | :parameters   | optional input parameters for a route, in a format defined by the coercion
+  | :responses    | optional descriptions of responses, in a format defined by coercion
+
+  Example:
+
+      [\"/api\"
+       {:openapi {:id :my-api}
+        :middleware [reitit.openapi/openapi-feature]}
+
+       [\"/openapi.json\"
+        {:get {:no-doc true
+               :openapi {:info {:title \"my-api\"}}
+               :handler reitit.openapi/openapi-spec-handler}}]
+
+       [\"/plus\"
+        {:get {:openapi {:tags \"math\"}
+               :summary \"adds numbers together\"
+               :description \"takes `x` and `y` query-params and adds them together\"
+               :parameters {:content {\"application/json\" {:x int?, :y int?}}}
+               :responses {200 {:content {\"application/json\" {:total pos-int?}}}}
+               :handler (fn [{:keys [parameters]}]
+                          {:status 200
+                           :body (+ (-> parameters :query :x)
+                                    (-> parameters :query :y))
+                           :headers {\"Content-Type\" \"application/json\"}})}}]]
+"
+  {:name ::openapi
+   :spec ::spec})
+
+(defn- openapi-path [path opts]
+  (-> path (trie/normalize opts) (str/replace #"\{\*" "{")))
+
+(defn create-openapi-handler
+  "Create a ring handler to emit openapi spec. Collects all routes from router which have
+  an intersecting `[:openapi :id]` and which are not marked with `:no-doc` route data."
+  []
+  (fn create-openapi
+    ([{::r/keys [router match] :keys [request-method]}]
+     (let [{:keys [id] :or {id ::default} :as openapi} (-> match :result request-method :data :openapi)
+           ids (trie/into-set id)
+           ;; TODO how to solve jsonSchemaDialect webhooks tags externalDocs
+           strip-top-level-keys #(dissoc % :id :info :jsonSchemaDialect :servers :paths :security :webhooks :tags :externalDocs)
+           strip-endpoint-keys #(dissoc % :id :summary :description :components)
+           openapi (->> (strip-endpoint-keys openapi)
+                        (merge {:openapi openapi-version
+                                :x-id ids}))
+           accept-route (fn [route]
+                          (-> route second :openapi :id (or :default) (trie/into-set) (set/intersection ids) seq))
+           base-openapi-spec {:responses ^:displace {:default {:description ""}}}
+           transform-endpoint (fn [[method {{:keys [coercion no-doc openapi] :as data} :data
+                                            middleware :middleware
+                                            interceptors :interceptors}]]
+                                (if (and data (not no-doc))
+                                  [method
+                                   (meta-merge
+                                    base-openapi-spec
+                                    (apply meta-merge (keep (comp :openapi :data) middleware))
+                                    (apply meta-merge (keep (comp :openapi :data) interceptors))
+                                    (if coercion
+                                      (coercion/get-apidocs coercion :openapi data))
+                                    (select-keys  data [:tags :summary :description])
+                                    (strip-top-level-keys openapi))]))
+           transform-path (fn [[p _ c]]
+                            (if-let [endpoint (some->> c (keep transform-endpoint) (seq) (into {}))]
+                              [(openapi-path p (r/options router)) endpoint]))
+
+           map-in-order #(->> % (apply concat) (apply array-map))
+           paths (->> router (r/compiled-routes) (filter accept-route) (map transform-path) map-in-order)]
+       {:status 200
+        :body (meta-merge openapi {:paths paths})}))
+    ([req res raise]
+     (try
+       (res (create-openapi req))
+       (catch #?(:clj Exception :cljs :default) e
+         (raise e))))))

--- a/test/cljc/reitit/openapi_test.clj
+++ b/test/cljc/reitit/openapi_test.clj
@@ -1,0 +1,434 @@
+(ns reitit.openapi-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [muuntaja.core :as m]
+            [reitit.coercion.malli :as malli]
+            [reitit.coercion.schema :as schema]
+            [reitit.coercion.spec :as spec]
+            [reitit.ring :as ring]
+            [reitit.ring.coercion :as rrc]
+            [reitit.openapi :as openapi]
+            [reitit.swagger-ui :as swagger-ui]
+            [schema.core :as s]
+            [spec-tools.data-spec :as ds]
+            [clojure.data.json]
+            [ring.util.response :as response]))
+
+(def app
+  (ring/ring-handler
+   (ring/router
+    ["/api"
+     {:openapi {:id ::math}}
+
+     ["/openapi.json"
+      {:get {:no-doc true
+             :openapi {:info {:title "my-api"}}
+             :handler (openapi/create-openapi-handler)}}]
+
+     ["/spec" {:coercion spec/coercion}
+      ["/plus/:z"
+       {:patch {:summary "patch"
+                :handler (constantly {:status 200})}
+        :options {:summary "options"
+                  :middleware [{:data {:openapi {:responses {200 {:description "200"}}}}}]
+                  :handler (constantly {:status 200})}
+        :get {:summary "plus"
+              :parameters {:query {:x int?, :y int?}
+                           :path {:z int?}}
+              :responses {200 {:content {"application/json" {:total int?}}}
+                          500 {:description "fail"}}
+              :handler (fn [{{{:keys [x y]} :query
+                              {:keys [z]} :path} :parameters}]
+                         ;; NOTE need to contain content-type
+                         (response/content-type
+                          {:status 200, :body {:total (+ x y z)}}
+                          "application/json"))}
+        :post {:summary "plus with body"
+               :parameters {:body (ds/maybe [int?])
+                            :path {:z int?}}
+               :responses {200 {:content {"application/json" {:total int?}}}
+                           500 {:description "fail"}}
+               :handler (fn [{{{:keys [z]} :path
+                               xs :body} :parameters}]
+                          (response/content-type
+                           {:status 200, :body {:total (+ (reduce + xs) z)}}
+                           "application/json"))}}]]
+     ;; TODO  malli support
+     ;; ["/malli" {:coercion malli/coercion}
+     ;;  ["/plus/*z"
+     ;;   {:get {:summary "plus"
+     ;;          :parameters {:query [:map [:x int?] [:y int?]]
+     ;;                       :path [:map [:z int?]]}
+     ;;          :openapi {:responses {400 {:schema {:type "string"}
+     ;;                                     :description "kosh"}}}
+     ;;          :responses {200 {:body [:map [:total int?]]}
+     ;;                      500 {:description "fail"}}
+     ;;          :handler (fn [{{{:keys [x y]} :query
+     ;;                          {:keys [z]} :path} :parameters}]
+     ;;                     {:status 200, :body {:total (+ x y z)}})}
+     ;;    :post {:summary "plus with body"
+     ;;           :parameters {:body [:maybe [:vector int?]]
+     ;;                        :path [:map [:z int?]]}
+     ;;           :openapi {:responses {400 {:schema {:type "string"}
+     ;;                                      :description "kosh"}}}
+     ;;           :responses {200 {:body [:map [:total int?]]}
+     ;;                       500 {:description "fail"}}
+     ;;           :handler (fn [{{{:keys [z]} :path
+     ;;                           xs :body} :parameters}]
+     ;;                      {:status 200, :body {:total (+ (reduce + xs) z)}})}}]]
+
+     ;; TODO schema supoort
+     ;; ["/schema" {:coercion schema/coercion}
+     ;;  ["/plus/*z"
+     ;;   {:get {:summary "plus"
+     ;;          :parameters {:query {:x s/Int, :y s/Int}
+     ;;                       :path {:z s/Int}}
+     ;;          :openapi {:responses {400 {:schema {:type "string"}
+     ;;                                     :description "kosh"}}}
+     ;;          :responses {200 {:body {:total s/Int}}
+     ;;                      500 {:description "fail"}}
+     ;;          :handler (fn [{{{:keys [x y]} :query
+     ;;                          {:keys [z]} :path} :parameters}]
+     ;;                     {:status 200, :body {:total (+ x y z)}})}
+     ;;    :post {:summary "plus with body"
+     ;;           :parameters {:body (s/maybe [s/Int])
+     ;;                        :path {:z s/Int}}
+     ;;           :openapi {:responses {400 {:schema {:type "string"}
+     ;;                                      :description "kosh"}}}
+     ;;           :responses {200 {:body {:total s/Int}}
+     ;;                       500 {:description "fail"}}
+     ;;           :handler (fn [{{{:keys [z]} :path
+     ;;                           xs :body} :parameters}]
+     ;;                      {:status 200, :body {:total (+ (reduce + xs) z)}})}}]]
+     ]
+
+    {:data {:middleware [openapi/openapi-feature
+                         rrc/coerce-exceptions-middleware
+                         rrc/coerce-request-middleware
+                         rrc/coerce-response-middleware]}})))
+
+(require '[fipp.edn])
+(deftest openapi-test
+  (testing "endpoints work"
+    (testing "spec"
+      (is (= {:body {:total 6}, :status 200, :headers {"Content-Type" "application/json"}}
+             (app {:request-method :get
+                   :uri "/api/spec/plus/3"
+                   :query-params {:x "2", :y "1"}})))
+      ;; (is (= {:body {:total 7}, :status 200, :headers {"Content-Type" "application/json"}}
+      ;;        (app {:request-method :post
+      ;;              :uri "/api/spec/plus/3"
+      ;;              :body-params [1 3]})))
+      )
+    ;; (testing "schema"
+    ;;   (is (= {:body {:total 6}, :status 200}
+    ;;          (app {:request-method :get
+    ;;                :uri "/api/schema/plus/3"
+    ;;                :query-params {:x "2", :y "1"}}))))
+    )
+  (testing "openapi-spec"
+    (let [spec (:body (app {:request-method :get
+                            :uri "/api/openapi.json"}))
+          expected {:x-id #{::math}
+                    :openapi "3.1.0"
+                    :info {:title "my-api"}
+                    :paths {"/api/spec/plus/{z}" {:patch {:parameters []
+                                                          :summary "patch"
+                                                          :responses {:default {:description ""}}}
+                                                  :options {:parameters []
+                                                            :summary "options"
+                                                            :responses {200 {:description "200"}}}
+                                                  :get {:parameters [{:in "query"
+                                                                      :name "x"
+                                                                      :description ""
+                                                                      :required true
+                                                                      :schema
+                                                                      {:type "integer"
+                                                                       :format "int64"}}
+                                                                     {:in "query"
+                                                                      :name "y"
+                                                                      :description ""
+                                                                      :required true
+                                                                      :schema
+                                                                      {:type "integer"
+                                                                       :format "int64"}}
+                                                                     {:in "path"
+                                                                      :name "z"
+                                                                      :description ""
+                                                                      :required true
+                                                                      :schema
+                                                                      {:type "integer"
+                                                                       :format "int64"}}]
+                                                        :responses {200 {:content
+                                                                         {"application/json"
+                                                                          {:schema {:type "object"
+                                                                                    :properties {"total" {:format "int64"
+                                                                                                          :type "integer"}}
+                                                                                    :required ["total"]}}}}
+                                                                    500 {:description "fail"}}
+                                                        :summary "plus"}
+                                                  :post {:parameters [{:name "array"
+                                                                       :in :body
+                                                                       :description ""
+                                                                       :required false
+                                                                       :schema
+                                                                       {:type "array", :items {:type "integer", :format "int64"}}}
+                                                                      {:name "z"
+                                                                       :in "path"
+                                                                       :description ""
+                                                                       :required true
+                                                                       :schema {:type "integer", :format "int64"}}]
+                                                         :responses {200 {:content
+                                                                          {"application/json"
+                                                                           {:schema {:properties {"total" {:format "int64"
+                                                                                                           :type "integer"}}
+                                                                                     :required ["total"]
+                                                                                     :type "object"}}}}
+                                                                     500 {:description "fail"}}
+                                                         :summary "plus with body"}}
+                            ;; "/api/malli/plus/{z}" {:get {:parameters [{:in "query"
+                            ;;                                            :name :x
+                            ;;                                            :description ""
+                            ;;                                            :required true
+                            ;;                                            :type "integer"
+                            ;;                                            :format "int64"}
+                            ;;                                           {:in "query"
+                            ;;                                            :name :y
+                            ;;                                            :description ""
+                            ;;                                            :required true
+                            ;;                                            :type "integer"
+                            ;;                                            :format "int64"}
+                            ;;                                           {:in "path"
+                            ;;                                            :name :z
+                            ;;                                            :description ""
+                            ;;                                            :required true
+                            ;;                                            :type "integer"
+                            ;;                                            :format "int64"}]
+                            ;;                              :responses {200 {:schema {:type "object"
+                            ;;                                                        :properties {:total {:format "int64"
+                            ;;                                                                             :type "integer"}}
+                            ;;                                                        :required [:total]}
+                            ;;                                               :description ""}
+                            ;;                                          400 {:schema {:type "string"}
+                            ;;                                               :description "kosh"}
+                            ;;                                          500 {:description "fail"}}
+                            ;;                              :summary "plus"}
+                            ;;                        :post {:parameters [{:in "body"
+                            ;;                                             :name "body"
+                            ;;                                             :description ""
+                            ;;                                             :required false
+                            ;;                                             :schema {:type "array"
+                            ;;                                                      :items {:type "integer"
+                            ;;                                                              :format "int64"}
+                            ;;                                                      :x-nullable true}}
+                            ;;                                            {:in "path"
+                            ;;                                             :name :z
+                            ;;                                             :description ""
+                            ;;                                             :type "integer"
+                            ;;                                             :required true
+                            ;;                                             :format "int64"}]
+                            ;;                               :responses {200 {:description ""
+                            ;;                                                :schema {:properties {:total {:format "int64"
+                            ;;                                                                              :type "integer"}}
+                            ;;                                                         :required [:total]
+                            ;;                                                         :type "object"}}
+                            ;;                                           400 {:schema {:type "string"}
+                            ;;                                                :description "kosh"}
+                            ;;                                           500 {:description "fail"}}
+                            ;;                               :summary "plus with body"}}
+                            ;; "/api/schema/plus/{z}" {:get {:parameters [{:description ""
+                            ;;                                             :format "int32"
+                            ;;                                             :in "query"
+                            ;;                                             :name "x"
+                            ;;                                             :required true
+                            ;;                                             :type "integer"}
+                            ;;                                            {:description ""
+                            ;;                                             :format "int32"
+                            ;;                                             :in "query"
+                            ;;                                             :name "y"
+                            ;;                                             :required true
+                            ;;                                             :type "integer"}
+                            ;;                                            {:in "path"
+                            ;;                                             :name "z"
+                            ;;                                             :description ""
+                            ;;                                             :type "integer"
+                            ;;                                             :required true
+                            ;;                                             :format "int32"}]
+                            ;;                               :responses {200 {:description ""
+                            ;;                                                :schema {:additionalProperties false
+                            ;;                                                         :properties {"total" {:format "int32"
+                            ;;                                                                               :type "integer"}}
+                            ;;                                                         :required ["total"]
+                            ;;                                                         :type "object"}}
+                            ;;                                           400 {:schema {:type "string"}
+                            ;;                                                :description "kosh"}
+                            ;;                                           500 {:description "fail"}}
+                            ;;                               :summary "plus"}
+                            ;;                         :post {:parameters [{:in "body"
+                            ;;                                              :name "body"
+                            ;;                                              :description ""
+                            ;;                                              :required false
+                            ;;                                              :schema {:type "array"
+                            ;;                                                       :items {:type "integer"
+                            ;;                                                               :format "int32"}
+                            ;;                                                       :x-nullable true}}
+                            ;;                                             {:in "path"
+                            ;;                                              :name "z"
+                            ;;                                              :description ""
+                            ;;                                              :type "integer"
+                            ;;                                              :required true
+                            ;;                                              :format "int32"}]
+                            ;;                                :responses {200 {:description ""
+                            ;;                                                 :schema {:properties {"total" {:format "int32"
+                            ;;                                                                                :type "integer"}}
+                            ;;                                                          :additionalProperties false
+                            ;;                                                          :required ["total"]
+                            ;;                                                          :type "object"}}
+                            ;;                                            400 {:schema {:type "string"}
+                            ;;                                                 :description "kosh"}
+                            ;;                                            500 {:description "fail"}}
+                            ;;                                :summary "plus with body"}}
+                            }}]
+      (is (= expected spec))
+
+      (testing "ring-async openapi-spec"
+        (let [response* (atom nil)
+              respond (partial reset! response*)]
+          (app {:request-method :get
+                :uri "/api/openapi.json"} respond (fn [_] (is false)))
+          (is (= expected (:body @response*))))))))
+
+(defn spec-paths [app uri]
+  (-> {:request-method :get, :uri uri} app :body :paths keys))
+
+(deftest multiple-openapi-apis-test
+  (let [ping-route ["/ping" {:get (constantly "ping")}]
+        spec-route ["/openapi.json"
+                    {:get {:no-doc true
+                           :handler (openapi/create-openapi-handler)}}]
+        app (ring/ring-handler
+             (ring/router
+              [["/common" {:openapi {:id #{::one ::two}}}
+                ping-route]
+
+               ["/one" {:openapi {:id ::one}}
+                ping-route
+                spec-route]
+
+               ["/two" {:openapi {:id ::two}}
+                ping-route
+                spec-route
+                ["/deep" {:openapi {:id ::one}}
+                 ping-route]]
+               ["/one-two" {:openapi {:id #{::one ::two}}}
+                spec-route]]))]
+    (is (= ["/common/ping" "/one/ping" "/two/deep/ping"]
+           (spec-paths app "/one/openapi.json")))
+    (is (= ["/common/ping" "/two/ping"]
+           (spec-paths app "/two/openapi.json")))
+    (is (= ["/common/ping" "/one/ping" "/two/ping" "/two/deep/ping"]
+           (spec-paths app "/one-two/openapi.json")))))
+
+(deftest openapi-ui-config-test
+  (let [app (swagger-ui/create-swagger-ui-handler
+             {:path "/"
+              :config {:jsonEditor true}})]
+    (is (= 302 (:status (app {:request-method :get, :uri "/"}))))
+    (is (= 200 (:status (app {:request-method :get, :uri "/index.html"}))))
+    (is (= {:jsonEditor true, :url "/openapi.json"}
+           (->> {:request-method :get, :uri "/config.json"}
+                (app) :body (m/decode m/instance "application/json"))))))
+
+(deftest without-openapi-id-test
+  (let [app (ring/ring-handler
+             (ring/router
+              [["/ping"
+                {:get (constantly "ping")}]
+               ["/openapi.json"
+                {:get {:no-doc true
+                       :handler (openapi/create-openapi-handler)}}]]))]
+    (is (= ["/ping"] (spec-paths app "/openapi.json")))
+    (is (= #{::openapi/default}
+           (-> {:request-method :get :uri "/openapi.json"}
+               (app) :body :x-id)))))
+
+(deftest with-options-endpoint-test
+  (let [app (ring/ring-handler
+             (ring/router
+              [["/ping"
+                {:options (constantly "options")}]
+               ["/pong"
+                (constantly "options")]
+               ["/openapi.json"
+                {:get {:no-doc true
+                       :handler (openapi/create-openapi-handler)}}]]))]
+    (is (= ["/ping" "/pong"] (spec-paths app "/openapi.json")))
+    (is (= #{::openapi/default}
+           (-> {:request-method :get :uri "/openapi.json"}
+               (app) :body :x-id)))))
+
+(deftest all-parameter-types-test
+  (let [app (ring/ring-handler
+             (ring/router
+              [["/parameters"
+                {:post {:coercion spec/coercion
+                        :parameters {:query {:q string?}
+                                     :body {:b string?}
+                                     :form {:f string?}
+                                     :header {:h string?}
+                                     :path {:p string?}}
+                        :handler identity}}]
+               ["/openapi.json"
+                {:get {:no-doc true
+                       :handler (openapi/create-openapi-handler)}}]]))
+        spec (:body (app {:request-method :get, :uri "/openapi.json"}))]
+    (is (= ["query" "body" "formData" "header" "path"]
+           (map :in (get-in spec [:paths "/parameters" :post :parameters]))))))
+
+;; (def app
+;;   (ring/ring-handler
+;;    (ring/router
+;;     ["/api"
+;;      {:openapi {:id ::math}}
+;;      ["/openapi.json"
+;;       {:get {:no-doc true
+;;              :openapi {:info {:title "my-api"}}
+;;              :handler (openapi/create-openapi-handler)}}]
+;;      ["/spec" {:coercion spec/coercion}
+;;       ["/plus/:z"
+;;        {:patch {:summary "patch"
+;;                 :handler (constantly {:status 200})}
+;;         :get {:summary "plus"
+;;               :parameters {:query {:x int?, :y int?}
+;;                            :path {:z int?}}
+;;               :responses {200 {:content {"application/json" {:total int?}}}
+;;                           500 {:description "fail"}}
+;;               :handler (fn [{{{:keys [x y]} :query
+;;                               {:keys [z]} :path} :parameters}]
+;;                          (response/content-type
+;;                           {:status 200, :body {:total (+ x y z)}}
+;;                           "application/json"))}}]]]
+;;     {:data {:middleware [openapi/openapi-feature
+;;                          rrc/coerce-exceptions-middleware
+;;                          rrc/coerce-request-middleware
+;;                          rrc/coerce-response-middleware]}})))
+
+;; (require '[fipp.edn])
+;; (deftest openapi-test
+;;   (testing "endpoints work"
+;;     (testing "spec"
+;;       (is (= {:body {:total 6} :status 200 :headers {"Content-Type" "application/json"}}
+;;              (app {:request-method :get
+;;                    :uri "/api/spec/plus/3"
+;;                    :query-params {:x "2" :y "1"}}))))
+;;     ;; (testing "openapi-spec"
+;;     ;;   (let [spec (:body (app {:request-method :get
+;;     ;;                           :uri "/api/openapi.json"}))]))
+;;     ))
+
+;; (app {:request-method :get
+;;       :uri "/api/spec/plus/3"
+;;       :query-params {:x "2" :y "1"}})
+
+(clojure.pprint/pprint
+ (app {:request-method :get
+       :uri "/api/openapi.json"}))


### PR DESCRIPTION
### restrictions
- need to use `content` in response, and should not use `body` 